### PR TITLE
商品編集画面のクッション画面と部分テンプレートの切り出し

### DIFF
--- a/app/assets/stylesheets/_posts.scss
+++ b/app/assets/stylesheets/_posts.scss
@@ -2001,4 +2001,54 @@ footer{
   }
 
  }
+////item.select////
+ .container{
+  margin: 24px auto 0;
+  padding: 0 0 40px;
+  @include mq(){
+    width: 700px;
+  }
+  @include mq(lg){
+    margin: 40px auto 0;
+    width: 1020px;
+  }
+ }
+ .content{
+  width: 100%;
+  @include mq(){
+    float:none;
+    width: 700px;
+  }
+  @include mq(lg){
+    float:right;
+  }
+ }
+ .item-change-box{
+  text-align: center;
+  margin: 24px 0 24px 0;
+  background: #fff;
+  padding: 8px 16px 8px 16px;
+  &__button{
+    display: block;
+    width: 100%;
+    line-height: 48px;
+    font-size: 14px;
+    border: 1px solid transparent;
+    -webkit-transition: all ease-out .3s;
+    transition: all ease-out .3s;
+    cursor: pointer;
+    text-align: center;
+    margin: 16px 0 16px 0;
+  }
+  .btn-red{
+    background: #ea352d;
+    border: 1px solid #ea352d;
+    color: #fff;
+  }
+  .btn-gray{
+    background: #aaa;
+    border: 1px solid #aaa;
+    color: #fff;
+  }
+ }
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,8 +3,8 @@ class ItemsController < ApplicationController
   def index
   end
 
-  def items
-  
+  def show
+    @item = Item.find(params[:id])
   end
 
 

--- a/app/views/items/_comment.html.haml
+++ b/app/views/items/_comment.html.haml
@@ -1,0 +1,10 @@
+.item__message
+  .item__message__box
+    .item__message__box__content
+      %form.item-message
+        %p<>
+          相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      %textarea.text-area
+      %button.message-submit
+        %span コメントする
+    %aside.item-modal

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,0 +1,55 @@
+%h1.item__box__name
+  aaaaaa
+.item__box__mein.clearfix
+  .item__box__mein__photo
+  .item-price-box.hyde
+    %span.item-price ¥999999
+    %span.item-tax (税込)
+    %span.item-postage 送料込み
+  %section.hyde
+    .item__box__mein__button
+      =link_to "購入画面に進む","",class:"item-buy-btn"
+  %table.item__box__mein__table
+    %tbody
+      %tr
+        %th 出品者
+        %td
+          =link_to "username","" 
+          %div
+            .item-rate
+              .icon-good
+            .item-rate
+              .icon-nomal
+            .item-rate
+              .icon-bad
+      %tr
+        %th カテゴリー
+        %td
+          =link_to "",""    
+      %tr
+        %th ブランド
+        %td
+          =link_to "",""
+      %tr
+        %th 商品のサイズ
+        %td
+      %tr
+        %th 商品の状態
+        %td
+      %tr
+        %th 配送料の負担
+        %td
+      %tr
+        %th 配送の方法
+        %td
+      %tr
+        %th 配送元地域
+        %td
+          =link_to "",""  
+      %tr
+        %th 発想日の目安
+        %td
+.item-price-box
+  %span.item-price ¥999999
+  %span.item-tax (税込)
+  %span.item-postage 送料込み

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -258,9 +258,9 @@
                       =image_tag src="https://web-jp-assets.mercdn.net/_next/static/images/app-store-a5c17948c6fd6d5b60b13d421cd60b35.svg",class:"appaddimg"
                     =link_to "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja" do
                       =image_tag src="https://web-jp-assets.mercdn.net/_next/static/images/google-play-495575abb895b405aa6336b2a4304958.svg",class:"appaddimg"  
-        .mein__row__sliders__left
-        .mein__row__sliders__right
-        .mein__row__sliders__bottom 
+        -# .mein__row__sliders__left
+        -# .mein__row__sliders__right
+        -# .mein__row__sliders__bottom 
     .mein__row__menu
       %h2.mein-menu-title.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv1__3ygH4 
         人気のカテゴリー
@@ -289,7 +289,7 @@
           .mein__row__new__box__lists__goods
             .mein__row__new__box__lists__goods__good
               .visibility
-                =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
+                =link_to items_item_path(@item) ,class:"style_link__3tLB3,style_fluidLink__WTcwb" do
                   %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
                     %figcaption
                       %span
@@ -299,163 +299,163 @@
                         ¥9999999999
                       =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
               
-      .mein__row__new__box
-        .mein__row__new__box__title.bottomSpace
-          %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
-            メンズ新着アイテム          
-          =link_to "",class:"mein__row__new__box__title__more" do
-            もっと見る
-        .mein__row__new__box__lists
-          .mein__row__new__box__lists__goods
-            .mein__row__new__box__lists__goods__good
-              .visibility
-                =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
-                  %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
-                    %figcaption
-                      %span
-                        ??????????
-                    .style_thumbnail__N_xAi
-                      %span{"aria-label":"Price"}
-                        ¥9999999999
-                      =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
+    -#   .mein__row__new__box
+    -#     .mein__row__new__box__title.bottomSpace
+    -#       %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
+    -#         メンズ新着アイテム          
+    -#       =link_to "",class:"mein__row__new__box__title__more" do
+    -#         もっと見る
+    -#     .mein__row__new__box__lists
+    -#       .mein__row__new__box__lists__goods
+    -#         .mein__row__new__box__lists__goods__good
+    -#           .visibility
+    -#             =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
+    -#               %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
+    -#                 %figcaption
+    -#                   %span
+    -#                     ??????????
+    -#                 .style_thumbnail__N_xAi
+    -#                   %span{"aria-label":"Price"}
+    -#                     ¥9999999999
+    -#                   =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
               
-      .mein__row__new__box
-        .mein__row__new__box__title.bottomSpace
-          %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
-            家電・スマホ・カメラ新着アイテム
-          =link_to "",class:"mein__row__new__box__title__more" do
-            もっと見る
-        .mein__row__new__box__lists
-          .mein__row__new__box__lists__goods
-            .mein__row__new__box__lists__goods__good
-              .visibility
-                =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
-                  %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
-                    %figcaption
-                      %span
-                        ??????????
-                    .style_thumbnail__N_xAi
-                      %span{"aria-label":"Price"}
-                        ¥9999999999
-                      =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
+    -#   .mein__row__new__box
+    -#     .mein__row__new__box__title.bottomSpace
+    -#       %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
+    -#         家電・スマホ・カメラ新着アイテム
+    -#       =link_to "",class:"mein__row__new__box__title__more" do
+    -#         もっと見る
+    -#     .mein__row__new__box__lists
+    -#       .mein__row__new__box__lists__goods
+    -#         .mein__row__new__box__lists__goods__good
+    -#           .visibility
+    -#             =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
+    -#               %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
+    -#                 %figcaption
+    -#                   %span
+    -#                     ??????????
+    -#                 .style_thumbnail__N_xAi
+    -#                   %span{"aria-label":"Price"}
+    -#                     ¥9999999999
+    -#                   =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
             
-      .mein__row__new__box
-        .mein__row__new__box__title.bottomSpace
-          %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
-            おもちゃ・ホビー・グッズ新着アイテム
-          =link_to "",class:"mein__row__new__box__title__more" do
-            もっと見る
-        .mein__row__new__box__lists
-          .mein__row__new__box__lists__goods
-            .mein__row__new__box__lists__goods__good
-              .visibility
-                =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
-                  %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
-                    %figcaption
-                      %span
-                        ??????????
-                    .style_thumbnail__N_xAi
-                      %span{"aria-label":"Price"}
-                        ¥9999999999
-                      =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
+    -#   .mein__row__new__box
+    -#     .mein__row__new__box__title.bottomSpace
+    -#       %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
+    -#         おもちゃ・ホビー・グッズ新着アイテム
+    -#       =link_to "",class:"mein__row__new__box__title__more" do
+    -#         もっと見る
+    -#     .mein__row__new__box__lists
+    -#       .mein__row__new__box__lists__goods
+    -#         .mein__row__new__box__lists__goods__good
+    -#           .visibility
+    -#             =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
+    -#               %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
+    -#                 %figcaption
+    -#                   %span
+    -#                     ??????????
+    -#                 .style_thumbnail__N_xAi
+    -#                   %span{"aria-label":"Price"}
+    -#                     ¥9999999999
+    -#                   =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
             
-    .mein__row__menu
-      %h2.mein-menu-title.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv1__3ygH4
-        人気のブランド
-      .mein__row__menu__tags
-        %ul.mein__row__menu__tags__lists
-          %li.mein__row__menu__tags__lists__list
-            =link_to "シャネル","",class:"mein__row__menu__tags__lists__list__tag"
-            =link_to "シャネル","",class:"mein__row__menu__tags__lists__list__stag"
-          %li.mein__row__menu__tags__lists__list
-            =link_to "ルイヴィトン","",class:"mein__row__menu__tags__lists__list__tag"
-            =link_to "ルイヴィトン","",class:"mein__row__menu__tags__lists__list__stag"
-          %li.mein__row__menu__tags__lists__list
-            =link_to "シュプリーム","",class:"mein__row__menu__tags__lists__list__tag"
-            =link_to "シュプリーム","",class:"mein__row__menu__tags__lists__list__stag"
-          %li.mein__row__menu__tags__lists__list
-            =link_to "ナイキ","",class:"mein__row__menu__tags__lists__list__tag"
-            =link_to "ナイキ","",class:"mein__row__menu__tags__lists__list__stag"
-    .mein__row__new
-      .mein__row__new__box
-        .mein__row__new__box__title.bottomSpace
-          %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
-            シャネル新着アイテム
-          =link_to "",class:"mein__row__new__box__title__more" do
-            もっと見る
-        .mein__row__new__box__lists
-          .mein__row__new__box__lists__goods
-            .mein__row__new__box__lists__goods__good
-              .visibility
-                =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
-                  %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
-                    %figcaption
-                      %span
-                        ??????????
-                    .style_thumbnail__N_xAi
-                      %span{"aria-label":"Price"}
-                        ¥9999999999
-                      =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
+    -# .mein__row__menu
+    -#   %h2.mein-menu-title.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv1__3ygH4
+    -#     人気のブランド
+    -#   .mein__row__menu__tags
+    -#     %ul.mein__row__menu__tags__lists
+    -#       %li.mein__row__menu__tags__lists__list
+    -#         =link_to "シャネル","",class:"mein__row__menu__tags__lists__list__tag"
+    -#         =link_to "シャネル","",class:"mein__row__menu__tags__lists__list__stag"
+    -#       %li.mein__row__menu__tags__lists__list
+    -#         =link_to "ルイヴィトン","",class:"mein__row__menu__tags__lists__list__tag"
+    -#         =link_to "ルイヴィトン","",class:"mein__row__menu__tags__lists__list__stag"
+    -#       %li.mein__row__menu__tags__lists__list
+    -#         =link_to "シュプリーム","",class:"mein__row__menu__tags__lists__list__tag"
+    -#         =link_to "シュプリーム","",class:"mein__row__menu__tags__lists__list__stag"
+    -#       %li.mein__row__menu__tags__lists__list
+    -#         =link_to "ナイキ","",class:"mein__row__menu__tags__lists__list__tag"
+    -#         =link_to "ナイキ","",class:"mein__row__menu__tags__lists__list__stag"
+    -# .mein__row__new
+    -#   .mein__row__new__box
+    -#     .mein__row__new__box__title.bottomSpace
+    -#       %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
+    -#         シャネル新着アイテム
+    -#       =link_to "",class:"mein__row__new__box__title__more" do
+    -#         もっと見る
+    -#     .mein__row__new__box__lists
+    -#       .mein__row__new__box__lists__goods
+    -#         .mein__row__new__box__lists__goods__good
+    -#           .visibility
+    -#             =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
+    -#               %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
+    -#                 %figcaption
+    -#                   %span
+    -#                     ??????????
+    -#                 .style_thumbnail__N_xAi
+    -#                   %span{"aria-label":"Price"}
+    -#                     ¥9999999999
+    -#                   =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
           
-      .mein__row__new__box
-        .mein__row__new__box__title.bottomSpace
-          %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
-            ルイヴィトン新着アイテム          
-          =link_to "",class:"mein__row__new__box__title__more" do
-            もっと見る
-        .mein__row__new__box__lists
-          .mein__row__new__box__lists__goods
-            .mein__row__new__box__lists__goods__good
-              .visibility
-                =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
-                  %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
-                    %figcaption
-                      %span
-                        ??????????
-                    .style_thumbnail__N_xAi
-                      %span{"aria-label":"Price"}
-                        ¥9999999999
-                      =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
+    -#   .mein__row__new__box
+    -#     .mein__row__new__box__title.bottomSpace
+    -#       %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
+    -#         ルイヴィトン新着アイテム          
+    -#       =link_to "",class:"mein__row__new__box__title__more" do
+    -#         もっと見る
+    -#     .mein__row__new__box__lists
+    -#       .mein__row__new__box__lists__goods
+    -#         .mein__row__new__box__lists__goods__good
+    -#           .visibility
+    -#             =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
+    -#               %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
+    -#                 %figcaption
+    -#                   %span
+    -#                     ??????????
+    -#                 .style_thumbnail__N_xAi
+    -#                   %span{"aria-label":"Price"}
+    -#                     ¥9999999999
+    -#                   =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
     
-      .mein__row__new__box
-        .mein__row__new__box__title.bottomSpace
-          %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
-            シュプリーム新着アイテム
-          =link_to "",class:"mein__row__new__box__title__more" do
-            もっと見る
-        .mein__row__new__box__lists
-          .mein__row__new__box__lists__goods
-            .mein__row__new__box__lists__goods__good
-              .visibility
-                =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
-                  %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
-                    %figcaption
-                      %span
-                        ??????????
-                    .style_thumbnail__N_xAi
-                      %span{"aria-label":"Price"}
-                        ¥9999999999
-                      =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
+    -#   .mein__row__new__box
+    -#     .mein__row__new__box__title.bottomSpace
+    -#       %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
+    -#         シュプリーム新着アイテム
+    -#       =link_to "",class:"mein__row__new__box__title__more" do
+    -#         もっと見る
+    -#     .mein__row__new__box__lists
+    -#       .mein__row__new__box__lists__goods
+    -#         .mein__row__new__box__lists__goods__good
+    -#           .visibility
+    -#             =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
+    -#               %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
+    -#                 %figcaption
+    -#                   %span
+    -#                     ??????????
+    -#                 .style_thumbnail__N_xAi
+    -#                   %span{"aria-label":"Price"}
+    -#                     ¥9999999999
+    -#                   =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
       
-      .mein__row__new__box
-        .mein__row__new__box__title.bottomSpace
-          %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
-            ナイキ新着アイテム
-          =link_to "",class:"mein__row__new__box__title__more" do
-            もっと見る
-        .mein__row__new__box__lists
-          .mein__row__new__box__lists__goods
-            .mein__row__new__box__lists__goods__good
-              .visibility
-                =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
-                  %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
-                    %figcaption
-                      %span
-                        ??????????
-                    .style_thumbnail__N_xAi
-                      %span{"aria-label":"Price"}
-                        ¥9999999999
-                      =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
+    -#   .mein__row__new__box
+    -#     .mein__row__new__box__title.bottomSpace
+    -#       %h3.mein__row__new__box__title__head.style_heading__3qSF6.common_fontFamily__3-3Si.style_responsiveLv2__3K0hn
+    -#         ナイキ新着アイテム
+    -#       =link_to "",class:"mein__row__new__box__title__more" do
+    -#         もっと見る
+    -#     .mein__row__new__box__lists
+    -#       .mein__row__new__box__lists__goods
+    -#         .mein__row__new__box__lists__goods__good
+    -#           .visibility
+    -#             =link_to "",class:"style_link__3tLB3,style_fluidLink__WTcwb" do
+    -#               %figure.style_card__1SiAF.style_responsiveLv1__26FNN.common_fontFamily__3-3Si.style_fluid__19gwX
+    -#                 %figcaption
+    -#                   %span
+    -#                     ??????????
+    -#                 .style_thumbnail__N_xAi
+    -#                   %span{"aria-label":"Price"}
+    -#                     ¥9999999999
+    -#                   =image_tag src="https://i.gyazo.com/e04f5279e2f6e215d8e5d59f1601d528.png"
         
 
 .form

--- a/app/views/items/item.html.haml
+++ b/app/views/items/item.html.haml
@@ -1,60 +1,7 @@
+=render 'header'
 .item
   %section.item__box
-    %h1.item__box__name
-      【ABCマート限定】itemname
-    .item__box__mein.clearfix
-      .item__box__mein__photo
-      .item-price-box.hyde
-        %span.item-price ¥999999
-        %span.item-tax (税込)
-        %span.item-postage 送料込み
-      %section.hyde
-        .item__box__mein__button
-          =link_to "購入画面に進む","",class:"item-buy-btn"
-      %table.item__box__mein__table
-        %tbody
-          %tr
-            %th 出品者
-            %td
-              =link_to "",""
-              %div
-                .item-rate
-                  .icon-good
-                .item-rate
-                  .icon-nomal
-                .item-rate
-                  .icon-bad
-          %tr
-            %th カテゴリー
-            %td
-              =link_to "",""    
-          %tr
-            %th ブランド
-            %td
-              =link_to "",""
-          %tr
-            %th 商品のサイズ
-            %td
-          %tr
-            %th 商品の状態
-            %td
-          %tr
-            %th 配送料の負担
-            %td
-          %tr
-            %th 配送の方法
-            %td
-          %tr
-            %th 配送元地域
-            %td
-              =link_to "",""  
-          %tr
-            %th 発想日の目安
-            %td
-    .item-price-box
-      %span.item-price ¥999999
-      %span.item-tax (税込)
-      %span.item-postage 送料込み
+    =render 'item'
     =link_to "購入画面に進む","",class:"item-buy-btn"
     =link_to "アプリで購入","",class:"item__box__appbutton","data-toggle":"open-app"
     .item__box__memo
@@ -79,16 +26,7 @@
         =link_to "" do
           =fa_icon "lock"
           %span あんしん・あんぜんへの取り組み
-  .item__message
-    .item__message__box
-      .item__message__box__content
-        %form.item-message
-          %p<>
-            相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
-        %textarea.text-area
-        %button.message-submit
-          %span コメントする
-      %aside.item-modal
+  =render 'comment'
   %ul.item__nav.clearfix
     %li.item__nav__prev
       =link_to "" do
@@ -302,4 +240,4 @@
         =fa_icon "chevron-right"
       %li
         %span 【ABCマート限定】adidas
-    
+=render 'footer'

--- a/app/views/items/select.html.haml
+++ b/app/views/items/select.html.haml
@@ -1,0 +1,19 @@
+-# 商品編集画面のクッション
+
+=render 'header'
+.item
+  .container.clearfix
+    .content
+      %section.item__box
+        =render 'item'
+      .item-change-box
+        =link_to "商品の編集","",class:"item-change-box__button btn-red"
+        %p or
+        %form
+          %button.item-change-box__button.btn-gray
+            出品を一旦停止する
+        %button.item-change-box__button.btn-gray
+          商品を削除する
+      =render 'comment'
+=render 'footer'
+  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   devise_for :users
   root "items#index"
 
+  get "items/show"
   get "items/item"
+  get "items/select"
   get "signups/registration"
   get "signups/newmember"
   get "signups/phonenumber"


### PR DESCRIPTION
#what
商品編集ボタンを押した際に移行するクッション画面を作成し、それに表示させる部分テンプレートをitemファイルから切り出して表示させた。
 
#why
クッションページにすることで操作性をあげるため